### PR TITLE
rm deprecated addIndentation

### DIFF
--- a/NodeExpression/Lambda.php
+++ b/NodeExpression/Lambda.php
@@ -18,54 +18,54 @@ abstract class Lambda extends \Twig_Node_Expression
     {
         $compiler->raw("\n");
         $compiler->indent();
-        $compiler->addIndentation();
+        $compiler->write('');
         $compiler->raw("function() use(&\$context) {\n");
         $compiler->indent();
 
         // copy of arguments and __ from context
         foreach ($arguments as $arg) {
-            $compiler->addIndentation();
+            $compiler->write('');
             $compiler->raw("if (isset(\$context['$arg'])) \$outer$arg = \$context['$arg'];\n");
         }
-        $compiler->addIndentation();
+        $compiler->write('');
         $compiler->raw("if (isset(\$context['__'])) \$outer__ = \$context['__'];\n");
 
         // adding closure's arguments to context
-        $compiler->addIndentation();
+        $compiler->write('');
         $compiler->raw("\$context['__'] = func_get_args();\n");
         foreach ($arguments as $i => $arg) {
-            $compiler->addIndentation();
+            $compiler->write('');
             $compiler->raw("if (func_num_args()>$i) \$context['$arg'] = func_get_arg($i);\n");
-            $compiler->addIndentation();
+            $compiler->write('');
             $compiler->raw("else unset(\$context['$arg']);\n");
         }
 
         // getting call result
-        $compiler->addIndentation();
+        $compiler->write('');
         $compiler->raw("\$result = ");
         $compiler->subcompile($this->getNode($expressionNode));
         $compiler->raw(";\n");
 
         // recreating original context
         foreach ($arguments as $arg) {
-            $compiler->addIndentation();
+            $compiler->write('');
             $compiler->raw("if (isset(\$outer$arg)) \$context['$arg'] = \$outer$arg ;\n");
-            $compiler->addIndentation();
+            $compiler->write('');
             $compiler->raw("else unset(\$context['$arg']);\n");
         }
-        $compiler->addIndentation();
+        $compiler->write('');
         $compiler->raw("if (isset(\$outer__)) \$context['__'] = \$outer__ ;\n");
-        $compiler->addIndentation();
+        $compiler->write('');
         $compiler->raw("else unset(\$context['__']);\n");
 
         // return statement
-        $compiler->addIndentation();
+        $compiler->write('');
         $compiler->raw("return \$result;\n");
         $compiler->outdent();
-        $compiler->addIndentation();
+        $compiler->write('');
 
         $compiler->raw("}\n");
         $compiler->outdent();
-        $compiler->addIndentation();
+        $compiler->write('');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^5.4 || ^7.0",
-        "twig/twig": "^1.0",
+        "twig/twig": "^1.0" || "^2.0",
         "dpolac/dictionary": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^5.4 || ^7.0",
-        "twig/twig": "^1.0" || "^2.0",
+        "twig/twig": "^1.0 || ^2.0",
         "dpolac/dictionary": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
As of Twig 1.27, the Twig_Compiler::addIndentation() has been deprecated. Use Twig_Compiler::write('') instead.