### PR TITLE
Fix #11 - Change operator to ==> to not conflict with built in => operator in Twig 2.10

### DIFF
--- a/LambdaExtension.php
+++ b/LambdaExtension.php
@@ -19,13 +19,13 @@ class LambdaExtension extends \Twig_Extension
     {
         return [
             [
-                '=>' => [
+                '==>' => [
                     'precedence' => 0,
                     'class' => '\DPolac\TwigLambda\NodeExpression\SimpleLambda'
                 ],
             ],
             [
-                '=>' => [
+                '==>' => [
                     'precedence' => 0,
                     'class' => '\DPolac\TwigLambda\NodeExpression\LambdaWithArguments',
                     'associativity' => \Twig_ExpressionParser::OPERATOR_LEFT

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
         "twig/twig": "^1.0 || ^2.0",
         "dpolac/dictionary": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,19 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": ">5.6",
         "twig/twig": "^1.0 || ^2.0",
-        "dpolac/dictionary": "^1.0"
+        "dpolac/dictionary": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0"
     },
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "git@github.com:pinfirelabs/dpolac-dictionary.git"
+		}
+	],
     "autoload": {
         "psr-4": {
             "DPolac\\TwigLambda\\": ""


### PR DESCRIPTION
Not a great fix, but suggested by @gmhenderson and appears to fix the issue, so thought I'd open a PR